### PR TITLE
Banner view: Don't show title over banner when banner art present

### DIFF
--- a/1080i/View_594_Banner.xml
+++ b/1080i/View_594_Banner.xml
@@ -98,7 +98,7 @@
 							<animation effect="fade" start="30" end="30" condition="true">Conditional</animation>
 						</control>
 						<control type="textbox">
-							<visible>String.IsEmpty(ListItem.Art(clearlogo))</visible>
+							<visible>String.IsEmpty(ListItem.Art(Banner)) + String.IsEmpty(ListItem.Art(clearlogo))</visible>
 							<left>10</left>
 							<top>10</top>
 							<width>480</width>
@@ -171,7 +171,7 @@
 							<animation effect="fade" start="5" end="5" condition="true">Conditional</animation>
 						</control>
 						<control type="textbox">
-							<visible>String.IsEmpty(ListItem.Art(clearlogo))</visible>
+							<visible>String.IsEmpty(ListItem.Art(Banner)) + String.IsEmpty(ListItem.Art(clearlogo))</visible>
 							<left>10</left>
 							<top>10</top>
 							<width>480</width>


### PR DESCRIPTION
### Overview
In the Banner view, title text should not display on top of banner items in the list. The 18.0 version of the skin did not do this; after updating to 19.0, my banner view got all messed up (device is Nvidia Shield/Android TV):

![Screenshot_20210310-002938](https://user-images.githubusercontent.com/709873/110830069-aeb32200-824d-11eb-826c-8a0965771356.png)

Here no clearlogo art was set. Setting it (to a screenshot of _Die Hard 2_) made the problem go away:

![Screenshot_20210310-002813](https://user-images.githubusercontent.com/709873/110830491-1ff2d500-824e-11eb-8a19-17012fa070ab.png)

### Proposed Change
Text should never display over an explicitly specified banner. The change makes the title textboxes test Banner presence for the visibility check: `String.IsEmpty(ListItem.Art(Banner))`

### Testing
I created a fresh installation of Kodi and added my library with all default scrapers and art. For one of the shows _(It's Always Sunny in Philadelphia)_, I set the art to the same configuration of art (different images but same presence of types). When testing I verified that the combinations selected, unselected, watched, and unwatched all display as expected. (Note that the other shows have clearlogos set so they don't exhibit the issue.)

Before change:
![kodiCapture2](https://user-images.githubusercontent.com/709873/110831942-9cd27e80-824f-11eb-90c5-4a6ce4867406.PNG)

After change:
![kodiCapture](https://user-images.githubusercontent.com/709873/110831970-a5c35000-824f-11eb-9eb0-02eedcb6a139.PNG)

